### PR TITLE
Set project default value

### DIFF
--- a/cup-maven-plugin/pom.xml
+++ b/cup-maven-plugin/pom.xml
@@ -40,8 +40,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <netbeans.hint.license>gpl20</netbeans.hint.license>
     <gpg.keyname>9D040841</gpg.keyname>
-    <compiler.source>1.8</compiler.source>
-    <compiler.target>1.8</compiler.target>
+    <compiler.source>1.7</compiler.source>
+    <compiler.target>1.7</compiler.target>
   </properties>
 
   <profiles>

--- a/cup-maven-plugin/src/main/java/com/github/vbmacher/cup/GoalGenerate.java
+++ b/cup-maven-plugin/src/main/java/com/github/vbmacher/cup/GoalGenerate.java
@@ -84,7 +84,7 @@ public class GoalGenerate extends AbstractMojo implements CupParameters {
     private File outputDirectory;
 
     /**
-     * @parameter property="project"
+     * @parameter default-value="${project}"
      * @required
      */
     private MavenProject project;


### PR DESCRIPTION
Without this, maven kept teling me this:

```
The parameters 'project' for goal com.github.vbmacher:cup-maven-plugin:1.0.1:generate are missing or invalid
```

I shouldn' have pushed the JDK stuff on this branch :-/ sorry, this a different issue (there seems to be no requirement for 1.8, so let's use an older version so that more people can use it)
