### PR TITLE
Fixes bug with directories as cup definition path

### DIFF
--- a/cup-maven-plugin/src/main/java/com/github/vbmacher/cup/CupParserGenerator.java
+++ b/cup-maven-plugin/src/main/java/com/github/vbmacher/cup/CupParserGenerator.java
@@ -49,7 +49,7 @@ public class CupParserGenerator {
         @Override
         public boolean accept(Path entry) throws IOException {
             File file = entry.toFile();
-            return file.isFile() && file.getName().toUpperCase().endsWith(".cup");
+            return file.isFile() && file.getName().toLowerCase().endsWith(".cup");
         }
     }
 


### PR DESCRIPTION
If a directory is specified as a cup definition path, then all .cup files contained in it will be ignored instead of reading them. This pull request fixes this issue.